### PR TITLE
Prepare dumbbell.cc for integration with training scripts

### DIFF
--- a/scratch/dumbbell.cc
+++ b/scratch/dumbbell.cc
@@ -169,6 +169,8 @@ int main (int argc, char *argv[])
   cmd.AddValue ("out_dir", "Directory in which to store output files.", outDir);
   cmd.Parse (argc, argv);
 
+  // Must specify at least one flow.
+  NS_ABORT_UNLESS (unfairFlows + otherFlows > 0);
   // Verify the protofol specified for the non-BBR flows.
   NS_ABORT_UNLESS (otherProto == "ns3::TcpNewReno" ||
                    otherProto == "ns3::TcpCubic" ||

--- a/scratch/dumbbell.cc
+++ b/scratch/dumbbell.cc
@@ -130,7 +130,7 @@ int main (int argc, char *argv[])
   std::string otherProto = "ns3::TcpNewReno";
   std::stringstream delaySs;
   delaySs << "[" << EDGE_DELAY_US << "]";
-  std::string unfairEdgeDelaysUs = delaySs.str();
+  std::string unfairEdgeDelaysUs = delaySs.str ();
   std::string otherEdgeDelaysUs = unfairEdgeDelaysUs;
   uint32_t payloadB = PAYLOAD_SIZE;
   bool enableUnfair = false;
@@ -247,7 +247,6 @@ int main (int argc, char *argv[])
                       StringValue (fairShareType));
   Config::SetDefault ("ns3::TcpSocketBase::AckPacingType",
                       StringValue (ackPacingType));
-  // updateAckPeriod (MicroSeconds(0));
   Config::SetDefault ("ns3::TcpSocketBase::AckPeriod",
                       TimeValue (MicroSeconds (0)));
   // Configure TcpSocketBase with the model filepath.
@@ -398,6 +397,7 @@ int main (int argc, char *argv[])
   /////////////////////////////////////////
   // Setup tracing (as appropriate).
   NS_LOG_INFO ("Configuring tracing.");
+
   std::stringstream detailsSs;
   detailsSs <<
     btlBw << "-" <<
@@ -422,8 +422,8 @@ int main (int argc, char *argv[])
 
   // Create output directory and base output filepath.
   outDir /= details;
-  NS_ABORT_UNLESS (! boost::filesystem::exists(outDir));
-  boost::filesystem::create_directory(outDir);
+  NS_ABORT_UNLESS (! boost::filesystem::exists (outDir));
+  boost::filesystem::create_directory (outDir);
   boost::filesystem::path outFlp = outDir;
   outFlp /= details;
 
@@ -432,7 +432,7 @@ int main (int argc, char *argv[])
       NS_LOG_INFO ("Enabling trace files.");
       AsciiTraceHelper ath;
       std::stringstream traceName;
-      traceName << outFlp.string() << ".tr";
+      traceName << outFlp.string () << ".tr";
       p2pRouter.EnableAsciiAll (ath.CreateFileStream (traceName.str ()));
     }
   if (pcap)

--- a/scratch/dumbbell.cc
+++ b/scratch/dumbbell.cc
@@ -406,20 +406,15 @@ int main (int argc, char *argv[])
     btlDel << "-" <<
     btlQueP << "p-" <<
     unfairFlows << "unfair-" <<
-    otherFlows << "other-";
-
-  if (unfairFlows + otherFlows > 0)
+    otherFlows << "other-" <<
+    edgeDelays[0];
+  for (uint32_t i = 1; i < unfairFlows + otherFlows; ++i)
     {
-      detailsSs << std::to_string (edgeDelays[0]);
-
-      for (uint32_t i = 1; i < unfairFlows + otherFlows; ++i)
-        {
-          detailsSs << "," << std::to_string (edgeDelays[i]);
-        }
-
-      detailsSs << "us-";
+      detailsSs << "," << edgeDelays[i];
     }
-  detailsSs << payloadB << "B-" << durS << "s";
+  detailsSs << "us-" <<
+    payloadB << "B-" <<
+    durS << "s";
   std::string details = detailsSs.str ();
 
   // Create output directory and base output filepath.

--- a/scratch/dumbbell.cc
+++ b/scratch/dumbbell.cc
@@ -24,7 +24,6 @@
 #include <chrono>
 #include <sstream>
 #include <string>
-#include <unordered_set>
 
 // ns-3 includes.
 #include "ns3/core-module.h"
@@ -46,28 +45,25 @@
 
 using namespace ns3;
 
-#define ENABLE_TRACE      false     // Set to "true" to enable trace.
-#define START_TIME        0.0       // Seconds
-#define S_PORT            911       // Well-known port for server.
-#define PACKET_SIZE       1380      // Bytes; Assumes 60 bytes for the IP
-                                    // header (20 bytes + up to 40 bytes for
-                                    // options) and a maximum of 60 bytes for
-                                    // the TCP header (20 bytes + up to 40
-                                    // bytes for options).
-#define MTU               1500      // Bytes
-#define HEADER_AND_OPTION 120       // Bytes
-#define PCAP_LEN          200       // Bytes
-#define EDGE_BW           "10Gbps"  // Bandwidth on the edge of the dumbell
-#define EDGE_QUEUE_SIZE   10000     // Queue size on the edge
-#define EDGE_DELAY_US     500       // Delay on the edge
+#define START_TIME         0.0       // Seconds
+#define S_PORT             911       // Well-known port for server.
+#define PAYLOAD_SIZE       1380      // Bytes; Assume an MTU of 1500. Assume 60
+                                     // bytes for the IP header (20 bytes + up
+                                     // to 40 bytes for options) and a maximum
+                                     // of 60 bytes for the TCP header (20 bytes
+                                     // + up to 40 bytes for options).
+#define HEADER_AND_OPTIONS 120       // Bytes
+#define PCAP_LEN           120       // Bytes
+#define EDGE_BW            "10Gbps"  // Bandwidth on the edge of the dumbell
+#define EDGE_QUEUE_SIZE    10000     // Queue size on the edge
+#define EDGE_DELAY_US      500       // Delay on the edge
+
 
 // For logging.
 NS_LOG_COMPONENT_DEFINE ("main");
 
-const int BBR_PRINT_PERIOD = 2;  // sec
-
+const int PRINT_PERIOD = 2;  // sec
 std::vector<Ptr<PacketSink>> sinks;
-extern bool useReno;
 
 void PrintStats ()
 {
@@ -83,137 +79,118 @@ void PrintStats ()
                    " Mb/s, avg lat: " << stats.avgLat.GetMicroSeconds () <<
                    " us, pending ACKs: " << sock->GetNumPendingAcks ());
     }
-  Simulator::Schedule (Seconds (BBR_PRINT_PERIOD), PrintStats);
+  Simulator::Schedule (Seconds (PRINT_PERIOD), PrintStats);
 }
 
 
-void ProcessEdgeDelayString (const std::string &delay_string, std::vector<uint32_t>& edge_delays,
+void ParseEdgeDelayString (const std::string &delay_string,
+                             std::vector<uint32_t>& edgeDelays,
                              uint32_t num_flows)
 {
-  if (delay_string.at(0) == '[' && delay_string.at(delay_string.length() - 1) == ']') {
-
-    // One delay value for all node pairs
-    uint32_t delay = std::stoi(delay_string.substr(1, delay_string.length() - 2));
-    for (uint32_t i = 0; i < num_flows; i++) {
-      edge_delays.push_back(delay);
-    }
-
-  } else {
-
-    // Parse comma seperated list
-    uint32_t prev_size = edge_delays.size();
-    std::stringstream ss(delay_string);
-    while (ss.good()) {
-      std::string edge_delay;
-      getline(ss, edge_delay, ',');
-      if (!edge_delay.empty()) {
-        edge_delays.push_back(std::stoi(edge_delay));
-      }
-    }
-    NS_ABORT_UNLESS(edge_delays.size() - prev_size == num_flows);
+  if (delay_string.at (0) == '[' &&
+      delay_string.at (delay_string.length () - 1) == ']')
+    {
+      // One delay value for all node pairs
+      uint32_t delay = std::stoi (
+        delay_string.substr (1, delay_string.length () - 2));
+      for (uint32_t i = 0; i < num_flows; ++i)
+        {
+          edgeDelays.push_back (delay);
+        }
   }
+  else
+    {
+      // Parse comma-seperated list
+      uint32_t prev_size = edgeDelays.size ();
+      std::stringstream ss (delay_string);
+      while (ss.good ())
+        {
+          std::string edge_delay;
+          getline (ss, edge_delay, ',');
+          if (! edge_delay.empty ())
+            {
+              edgeDelays.push_back (std::stoi (edge_delay));
+            }
+        }
+      NS_ABORT_UNLESS (edgeDelays.size () - prev_size == num_flows);
+    }
 }
 
 
 int main (int argc, char *argv[])
 {
   // Parse command line arguments.
-  double bwMbps = 10;
+  double btlBwMbps = 10;
   double btlDelUs = 5000;
   uint32_t btlQueP = 1000;
-  std::string unfairEdgeDelayUs = "";
-  std::string otherEdgeDelayUs = "";
-  uint32_t packet_size = PACKET_SIZE;
-  uint32_t mtu = MTU;
-  double durS = 20;
-  double warmupS = 5;
-  bool pcap = false;
-  std::string modelFlp = "";
-  std::string outDir = ".";
   uint32_t unfairFlows = 1;
   uint32_t otherFlows = 0;
   std::string otherProto = "ns3::TcpNewReno";
+  std::stringstream delaySs;
+  delaySs << "[" << EDGE_DELAY_US << "]";
+  std::string unfairEdgeDelaysUs = delaySs.str();
+  std::string otherEdgeDelaysUs = unfairEdgeDelaysUs;
+  uint32_t payloadB = PAYLOAD_SIZE;
   bool enableUnfair = false;
   std::string fairShareType = "Mathis";
   std::string ackPacingType = "Calc";
-
+  std::string modelFlp = "";
+  double durS = 20;
+  double warmupS = 5;
+  bool pcap = false;
+  bool trace = false;
+  std::string outDir = ".";
   const char *edge_delay_usage = "List of the edge delays (us) for unfair flows in the "
                                  "dumbbell topology seperated by comma."
                                  "Be mindful that both left and right edge will have the same delay. "
                                  "Edges will have the default delay (500us) if not specified"
                                  "(e.g. \"1000,500,1000,2000\"). Also, there's a shortcut to specify the same "
                                  "delay for all flows, using [1000] instead of comma seperated string.";
-
   CommandLine cmd;
-  cmd.AddValue ("bandwidth_Mbps", "Bandwidth for the bottleneck router (Mbps).", bwMbps);
-  cmd.AddValue ("bottleneck_delay_us", "Bottleneck link delay (us).", btlDelUs);
-  cmd.AddValue ("queue_capacity_p", "Router queue size at bottleneck router (packets).", btlQueP);
-  cmd.AddValue ("unfair_edge_delay_us", edge_delay_usage, unfairEdgeDelayUs);
-  cmd.AddValue ("other_edge_delay_us", "Edge delay for other flows (ms)", otherEdgeDelayUs);
-  cmd.AddValue ("packet_size", "Size of a single packet (bytes)", packet_size);
-  cmd.AddValue ("experiment_duration_s", "Simulation duration (s).", durS);
-  cmd.AddValue ("warmup_s", "Time before delaying ACKs (s)", warmupS);
-  cmd.AddValue ("pcap", "Record a pcap trace from each port (true or false).", pcap);
-  cmd.AddValue ("model", "Path to the model file.", modelFlp);
-  cmd.AddValue ("out_dir", "Directory in which to store output files.", outDir);
+  cmd.AddValue ("bottleneck_bandwidth_Mbps", "Bandwidth for the bottleneck link (Mbps).", btlBwMbps);
+  cmd.AddValue ("bottleneck_delay_us", "Delay across the bottleneck link (us).", btlDelUs);
+  cmd.AddValue ("bottleneck_queue_p", "Router queue size at bottleneck link (packets).", btlQueP);
   cmd.AddValue ("unfair_flows", "Number of BBR flows.", unfairFlows);
   cmd.AddValue ("other_flows", "Number of non-BBR flows.", otherFlows);
   cmd.AddValue ("other_proto", "The TCP variant to use (e.g., \"ns3::TcpCubic\") for the non-BBR flows.", otherProto);
+  cmd.AddValue ("unfair_edge_delays_us", edge_delay_usage, unfairEdgeDelaysUs);
+  cmd.AddValue ("other_edge_delays_us", "Edge delays for other flows (us). See '--unfair_edge_delay_us' for more info.", otherEdgeDelaysUs);
+  cmd.AddValue ("payload_B", "Size of a single packet payload (bytes)", payloadB);
   cmd.AddValue ("enable_mitigation", "Enable unfairness mitigation (true or false).", enableUnfair);
   cmd.AddValue ("fair_share_type", "How to estimate the bandwidth fair share.", fairShareType);
   cmd.AddValue ("ack_pacing_type", "How to estimate ACK pacing interval.", ackPacingType);
+  cmd.AddValue ("model", "Path to the model file.", modelFlp);
+  cmd.AddValue ("duration_s", "Simulation duration (s).", durS);
+  cmd.AddValue ("warmup_s", "Time before delaying ACKs (s)", warmupS);
+  cmd.AddValue ("pcap", "Record a pcap trace from each port (true or false).", pcap);
+  cmd.AddValue ("trace", "Enable tracing (true or false).", trace);
+  cmd.AddValue ("out_dir", "Directory in which to store output files.", outDir);
   cmd.Parse (argc, argv);
 
   // Verify the protofol specified for the non-BBR flows.
   NS_ABORT_UNLESS (otherProto == "ns3::TcpNewReno" ||
                    otherProto == "ns3::TcpCubic" ||
                    otherProto == "ns3::TcpBbr");
-
-  uint32_t rttUs = (btlDelUs + EDGE_DELAY_US * 2) * 2;
-
-  // Number of Nodes
-  uint32_t num_nodes = unfairFlows + otherFlows;
-
-  // Bandwidth
-  std::stringstream bwSs;
-  bwSs << bwMbps << "Mbps";
-  std::string bw = bwSs.str ();
-
-  // Delay
+  // Make sure that the MTU is large enough.
+  uint32_t mtu = payloadB + HEADER_AND_OPTIONS;
+  // Number of nodes.
+  uint32_t numNodes = unfairFlows + otherFlows;
+  // Bottleneck link bandwidth.
+  std::stringstream btlBwSs;
+  btlBwSs << btlBwMbps << "Mbps";
+  std::string btlBw = btlBwSs.str ();
+  // Bottleneck link delay.
   std::stringstream btlDelSs;
   btlDelSs << btlDelUs << "us";
   std::string btlDel = btlDelSs.str ();
-
-  // Queue size
+  // Bottleneck queue capacity.
   std::stringstream btlQueSs;
   btlQueSs << btlQueP << "p";
   std::string btlQue = btlQueSs.str ();
-
-  double routerToDstBW = bwMbps;
-  std::stringstream sndSS;
-  sndSS << routerToDstBW << "Mbps";
-  std::string btlBWStr = sndSS.str ();
-
-  mtu = packet_size + HEADER_AND_OPTION;
-
-  // Edge delays
-  std::vector<uint32_t> edge_delays;
-
-  if (!unfairEdgeDelayUs.empty()) {
-    ProcessEdgeDelayString(unfairEdgeDelayUs, edge_delays, unfairFlows);
-  } else {
-    for (uint32_t i = 0; i < unfairFlows; ++i) {
-      edge_delays.push_back(EDGE_DELAY_US);
-    }
-  }
-
-  if (!otherEdgeDelayUs.empty()) {
-    ProcessEdgeDelayString(otherEdgeDelayUs, edge_delays, otherFlows);
-  } else {
-    for (uint32_t i = 0; i < otherFlows; ++i) {
-      edge_delays.push_back(EDGE_DELAY_US);
-    }
-  }
+  // Edge delays.
+  std::vector<uint32_t> edgeDelays;
+  ParseEdgeDelayString (unfairEdgeDelaysUs, edgeDelays, unfairFlows);
+  ParseEdgeDelayString (otherEdgeDelaysUs, edgeDelays, otherFlows);
 
   /////////////////////////////////////////
   // Turn on logging and report parameters.
@@ -221,30 +198,27 @@ int main (int argc, char *argv[])
   //       and "BbrState".
   LogComponentEnable ("main", LOG_LEVEL_INFO);
 
-  NS_LOG_INFO ("\n" <<
-               "Bottleneck router bandwidth: " << bw << "\n" <<
-               "Bottleneck router delay: " << btlDel << "\n" <<
-               "Edge bandwidth: " << EDGE_BW);
 
-  std::stringstream edge_delay_ss;
-  edge_delay_ss << "Edge delays: ";
-  for (uint32_t i = 0; i < num_nodes; i++) {
-    edge_delay_ss << std::to_string(edge_delays[i]) << "us ";
-  }
-
-  NS_LOG_INFO(edge_delay_ss.str());
-
-  NS_LOG_INFO( "RTT: " << rttUs << "us\n" <<
-               "Packet size: " << packet_size << " bytes\n" <<
-               "Bottleneck router queue capacity: "<< btlQueP << " packets\n" <<
-               "BBR flows: " << unfairFlows << "\n" <<
-               "Non-BBR flows: " << otherFlows << "\n" <<
-               "Non-BBR protocol: " << otherProto << "\n" <<
-               "Duration: " << durS << "s\n" <<
-               "Enable unfairness mitigation: " << (enableUnfair ? "yes" : "no") << "\n" <<
-               "Fair share estimation type: " << fairShareType << "\n" <<
-               "ACK pacing estimation type: " << ackPacingType << "\n" <<
-               "Model: " << modelFlp << "\n");
+  NS_LOG_INFO ("\nBottleneck link bandwidth (Mbps): " << btlBwMbps <<
+               "\nBottleneck link delay (us): " << btlDelUs <<
+               "\nBottleneck router queue capacity (p): "<< btlQueP <<
+               "\nEdge bandwidth: " << EDGE_BW <<
+               "\nUnfair flows: " << unfairFlows <<
+               "\nOther flows: " << otherFlows <<
+               "\nOther protocol: " << otherProto <<
+               "\nUnfair flows edge delays (us): " << unfairEdgeDelaysUs <<
+               "\nOther flows edge delays (us): " << otherEdgeDelaysUs <<
+               "\nPacket payload size (B): " << payloadB <<
+               "\nEnable unfairness mitigation: " <<
+               (enableUnfair ? "yes" : "no") <<
+               "\nFair share estimation type: " << fairShareType <<
+               "\nACK pacing estimation type: " << ackPacingType <<
+               "\nModel: " << modelFlp <<
+               "\nSimulation duration (s): " << durS <<
+               "\nWarmup (s): " << warmupS <<
+               "\nCapture PCAP: " << (pcap ? "yes" : "no") <<
+               "\nCapture traces: " << (trace ? "yes" : "no") <<
+               "\nOutput directory: " << outDir << "\n");
 
   /////////////////////////////////////////
   // Configure parameters.
@@ -252,10 +226,11 @@ int main (int argc, char *argv[])
   ConfigStore config;
   config.ConfigureDefaults ();
   // Select which TCP variant to use.
-  Config::SetDefault ("ns3::TcpL4Protocol::SocketType", StringValue (otherProto));
+  Config::SetDefault ("ns3::TcpL4Protocol::SocketType",
+                      StringValue (otherProto));
   // Set the segment size (otherwise, ns-3's default is 536).
   Config::SetDefault ("ns3::TcpSocket::SegmentSize",
-                      UintegerValue (packet_size));
+                      UintegerValue (payloadB));
   // Turn off delayed ACKs (so that every packet results in an ACK).
   // Note: BBR still works without this.
   Config::SetDefault ("ns3::TcpSocket::DelAckCount", UintegerValue (0));
@@ -282,159 +257,184 @@ int main (int argc, char *argv[])
   Config::SetDefault ("ns3::TcpSocketBase::MaxPacketRecords",
                       UintegerValue (10000));
 
-  // p2pRouter is the link connecting bridge 1 and bridge 2 in the graph above (bottleneck router)
+  // p2pRouter is the link connecting bridge 1 and bridge 2 in the
+  // graph above (bottleneck router).
   PointToPointHelper p2pRouter (PCAP_LEN);
-  p2pRouter.SetDeviceAttribute ("DataRate", StringValue (btlBWStr));
+  p2pRouter.SetDeviceAttribute ("DataRate", StringValue (btlBw));
   p2pRouter.SetChannelAttribute ("Delay", StringValue (btlDel));
   p2pRouter.SetDeviceAttribute ("Mtu", UintegerValue (mtu));
   p2pRouter.SetQueue ("ns3::DropTailQueue", "MaxSize", QueueSizeValue (btlQue));
 
-  // p2pLeaf are symmetric links that connect senders to bridege 1 and receivers to bridge 2
-  // It is used twice in the creation of PointToPointDumbbellHelper
+  // p2pLeaf are symmetric links that connect senders to bridege 1 and
+  // receivers to bridge 2. It is used twice in the creation of
+  // PointToPointDumbbellHelper
   PointToPointHelper p2pLeaf (PCAP_LEN);
   p2pLeaf.SetDeviceAttribute ("DataRate", StringValue (EDGE_BW));
-  p2pLeaf.SetChannelAttribute ("Delay", StringValue (std::to_string(EDGE_DELAY_US) + "us"));
+  p2pLeaf.SetChannelAttribute (
+    "Delay", StringValue (std::to_string (EDGE_DELAY_US) + "us"));
   p2pLeaf.SetDeviceAttribute ("Mtu", UintegerValue (mtu));
-  p2pLeaf.SetQueue ("ns3::DropTailQueue", "MaxSize", QueueSizeValue (std::to_string(EDGE_QUEUE_SIZE) + "p"));
+  p2pLeaf.SetQueue ("ns3::DropTailQueue", "MaxSize",
+                    QueueSizeValue (std::to_string (EDGE_QUEUE_SIZE) + "p"));
 
-  PointToPointDumbbellHelper dumbBellTopology(num_nodes, p2pLeaf, num_nodes,
-                                             p2pLeaf, p2pRouter);
+  PointToPointDumbbellHelper dumbBellTopology (numNodes, p2pLeaf, numNodes,
+                                               p2pLeaf, p2pRouter);
 
-  for (uint32_t i = 0; i < num_nodes; ++i) {
-    Ptr<Node> leftNode = dumbBellTopology.GetLeft(i);
-    Ptr<Node> rightNode = dumbBellTopology.GetRight(i);
+  for (uint32_t i = 0; i < numNodes; ++i)
+    {
+      Ptr<Node> leftNode = dumbBellTopology.GetLeft (i);
+      Ptr<Node> rightNode = dumbBellTopology.GetRight (i);
 
-    Ptr<Channel> leftNodeChannel = leftNode->GetDevice(0)->GetChannel();
-    Ptr<Channel> rightNodeChannel = rightNode->GetDevice(0)->GetChannel();
+      Ptr<Channel> leftNodeChannel = leftNode->GetDevice (0)->GetChannel ();
+      Ptr<Channel> rightNodeChannel = rightNode->GetDevice (0)->GetChannel ();
 
-    leftNodeChannel->SetAttribute("Delay", TimeValue(MicroSeconds(edge_delays[i])));
-    rightNodeChannel->SetAttribute("Delay", TimeValue(MicroSeconds(edge_delays[i])));
-  }
+      leftNodeChannel->SetAttribute (
+        "Delay", TimeValue (MicroSeconds (edgeDelays[i])));
+      rightNodeChannel->SetAttribute (
+        "Delay", TimeValue (MicroSeconds (edgeDelays[i])));
+    }
 
   // Install stack
   InternetStackHelper stack;
-  dumbBellTopology.InstallStack(stack);
+  dumbBellTopology.InstallStack (stack);
 
   // Assign IP Addresses
-  dumbBellTopology.AssignIpv4Addresses(Ipv4AddressHelper("10.1.0.0", "/24"),  // Left Nodes
-                                       Ipv4AddressHelper("20.1.0.0", "/24"),  // Right Nodes
-                                       Ipv4AddressHelper("30.1.0.0", "/24")); // Router address
+  dumbBellTopology.AssignIpv4Addresses (Ipv4AddressHelper ("10.1.0.0", "/24"),  // Left Nodes
+                                        Ipv4AddressHelper ("20.1.0.0", "/24"),  // Right Nodes
+                                        Ipv4AddressHelper ("30.1.0.0", "/24")); // Router address
 
   NodeContainer leftNodes, rightNodes;
-  for (uint32_t k = 0; k < num_nodes; ++k) {
-    leftNodes.Add(dumbBellTopology.GetLeft(k));
-    rightNodes.Add(dumbBellTopology.GetRight(k));
-  }
-
-  Ptr<Node> leftRTR = dumbBellTopology.GetLeft();
-  Ptr<Node> rightRTR = dumbBellTopology.GetRight();
-  Ptr <Ipv4> ipL_RTR = leftRTR->GetObject<Ipv4>();
-  Ptr <Ipv4> ipR_RTR = rightRTR->GetObject<Ipv4>();
-
-  Ipv4StaticRoutingHelper staticRouting;
-  for (uint32_t i = 0; i < num_nodes; ++i) {
-    Ptr<Ipv4> ipv4 = leftNodes.Get(i)->GetObject<Ipv4>();
-    Ptr<Ipv4StaticRouting> routeTable = staticRouting.GetStaticRouting(ipv4);
-    routeTable->AddNetworkRouteTo(Ipv4Address("0.0.0.0"), Ipv4Mask("0.0.0.0"), 1);
+  for (uint32_t k = 0; k < numNodes; ++k)
+    {
+      leftNodes.Add (dumbBellTopology.GetLeft (k));
+      rightNodes.Add (dumbBellTopology.GetRight (k));
     }
 
-  for (uint32_t i = 0; i < num_nodes; ++i) {
-    Ptr<Ipv4> ipv4 = rightNodes.Get(i)->GetObject<Ipv4>();
-    Ptr<Ipv4StaticRouting> routeTable = staticRouting.GetStaticRouting(ipv4);
-    routeTable->AddNetworkRouteTo(Ipv4Address("0.0.0.0"), Ipv4Mask("0.0.0.0"), 1);
-  }
+  Ptr<Node> leftRTR = dumbBellTopology.GetLeft ();
+  Ptr<Node> rightRTR = dumbBellTopology.GetRight ();
+  Ptr <Ipv4> ipL_RTR = leftRTR->GetObject<Ipv4> ();
+  Ptr <Ipv4> ipR_RTR = rightRTR->GetObject<Ipv4> ();
 
-  Ptr <Ipv4StaticRouting> leftRTR_routeTable = staticRouting.GetStaticRouting(ipL_RTR);
-  leftRTR_routeTable->AddNetworkRouteTo(Ipv4Address("20.0.0.0"), Ipv4Mask("/7"), 1);
+  Ipv4StaticRoutingHelper staticRouting;
+  for (uint32_t i = 0; i < numNodes; ++i)
+    {
+      Ptr<Ipv4> ipv4 = leftNodes.Get (i)->GetObject<Ipv4> ();
+      Ptr<Ipv4StaticRouting> routeTable = staticRouting.GetStaticRouting (ipv4);
+      routeTable->AddNetworkRouteTo (Ipv4Address ("0.0.0.0"),
+                                     Ipv4Mask ("0.0.0.0"), 1);
+    }
 
-  for (uint32_t i = 0; i < num_nodes; ++i) {
-    leftRTR_routeTable->AddHostRouteTo(
-      leftNodes.Get(i)->GetObject<Ipv4>()->GetAddress(1, 0).GetLocal(),
-      int(i + 2));
-  }
+  for (uint32_t i = 0; i < numNodes; ++i)
+    {
+      Ptr<Ipv4> ipv4 = rightNodes.Get (i)->GetObject<Ipv4> ();
+      Ptr<Ipv4StaticRouting> routeTable = staticRouting.GetStaticRouting (ipv4);
+      routeTable->AddNetworkRouteTo (Ipv4Address ("0.0.0.0"),
+                                     Ipv4Mask ("0.0.0.0"), 1);
+    }
 
-  Ptr <Ipv4StaticRouting> rightRTR_routeTable = staticRouting.GetStaticRouting(ipR_RTR);
-  rightRTR_routeTable->AddNetworkRouteTo(Ipv4Address("10.0.0.0"), Ipv4Mask("/7"), 1);
-  for (uint32_t i = 0; i < num_nodes; ++i) {
-    rightRTR_routeTable->AddHostRouteTo(
-      rightNodes.Get(i)->GetObject<Ipv4>()->GetAddress(1, 0).GetLocal(),
-      int(i + 2));
-  }
+  Ptr <Ipv4StaticRouting> leftRTR_routeTable = staticRouting.GetStaticRouting (
+    ipL_RTR);
+  leftRTR_routeTable->AddNetworkRouteTo (Ipv4Address ("20.0.0.0"),
+                                         Ipv4Mask ("/7"), 1);
+
+  for (uint32_t i = 0; i < numNodes; ++i)
+    {
+      leftRTR_routeTable->AddHostRouteTo (
+        leftNodes.Get (i)->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal (),
+        int (i + 2));
+    }
+
+  Ptr <Ipv4StaticRouting> rightRTR_routeTable = staticRouting.GetStaticRouting (
+    ipR_RTR);
+  rightRTR_routeTable->AddNetworkRouteTo (Ipv4Address ("10.0.0.0"),
+                                          Ipv4Mask ("/7"), 1);
+  for (uint32_t i = 0; i < numNodes; ++i)
+    {
+      rightRTR_routeTable->AddHostRouteTo (
+        rightNodes.Get (i)->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal (),
+        int (i + 2));
+    }
 
   uint32_t port = 100;
 
-  PacketSinkHelper sink("ns3::TcpSocketFactory",
-                          InetSocketAddress(Ipv4Address::GetAny(), port));
+  PacketSinkHelper sink ("ns3::TcpSocketFactory",
+                         InetSocketAddress (Ipv4Address::GetAny (), port));
 
-  ApplicationContainer rightSinkApp = sink.Install(rightNodes);
-  rightSinkApp.Start(Seconds(START_TIME));
-  rightSinkApp.Stop(Seconds(START_TIME + durS));
+  ApplicationContainer rightSinkApp = sink.Install (rightNodes);
+  rightSinkApp.Start (Seconds (START_TIME));
+  rightSinkApp.Stop (Seconds (START_TIME + durS));
 
-  for (uint32_t i = 0; i < num_nodes; ++i) {
-    sinks.push_back(DynamicCast<PacketSink>(rightSinkApp.Get(i)));
-  }
-
-  for (uint32_t i = 0; i < num_nodes; ++i) {
-    Ptr <Node> right = rightNodes.Get(i);
-    BulkSendHelper sender("ns3::TcpSocketFactory",
-                              InetSocketAddress(right->GetObject<Ipv4>()->GetAddress(1, 0).GetLocal(),
-                                                port));
-    sender.SetAttribute("MaxBytes", UintegerValue(0));
-    sender.SetAttribute("SendSize", UintegerValue (packet_size));
-
-    // Set congestion control type
-
-    if (i < unfairFlows) {
-      sender.SetAttribute("CongestionType", StringValue("ns3::TcpBbr"));
-    } else {
-      sender.SetAttribute("CongestionType", StringValue(otherProto));
+  for (uint32_t i = 0; i < numNodes; ++i)
+    {
+      sinks.push_back (DynamicCast<PacketSink> (rightSinkApp.Get (i)));
     }
-    ApplicationContainer sendApps = sender.Install(leftNodes.Get(i));
-    sendApps.Start(Seconds(START_TIME));
-    sendApps.Stop(Seconds(START_TIME + durS));
-  }
+
+  for (uint32_t i = 0; i < numNodes; ++i)
+    {
+      Ptr <Node> right = rightNodes.Get (i);
+      BulkSendHelper sender (
+        "ns3::TcpSocketFactory",
+        InetSocketAddress (
+          right->GetObject<Ipv4> ()->GetAddress (1, 0).GetLocal (), port));
+      sender.SetAttribute ("MaxBytes", UintegerValue (0));
+      sender.SetAttribute ("SendSize", UintegerValue (payloadB));
+
+      // Set congestion control type
+      if (i < unfairFlows)
+        {
+          sender.SetAttribute ("CongestionType", StringValue ("ns3::TcpBbr"));
+        }
+      else
+        {
+          sender.SetAttribute ("CongestionType", StringValue (otherProto));
+        }
+
+      ApplicationContainer sendApps = sender.Install (leftNodes.Get (i));
+      sendApps.Start (Seconds (START_TIME));
+      sendApps.Stop (Seconds (START_TIME + durS));
+    }
 
   /////////////////////////////////////////
   // Setup tracing (as appropriate).
   NS_LOG_INFO ("Configuring tracing.");
   std::stringstream detailsSs;
   detailsSs <<
-    bw << "-" <<
-    btlDelUs << "us-" <<
+    btlBw << "-" <<
+    btlDel << "-" <<
     btlQueP << "p-" <<
     unfairFlows << "unfair-" <<
     otherFlows << "other-";
 
-  if (unfairFlows + otherFlows > 0) {
-    detailsSs << std::to_string(edge_delays[0]);
+  if (unfairFlows + otherFlows > 0)
+    {
+      detailsSs << std::to_string (edgeDelays[0]);
 
-    for (uint32_t i = 1; i < unfairFlows + otherFlows; ++i) {
-      detailsSs << "," << std::to_string(edge_delays[i]);
+      for (uint32_t i = 1; i < unfairFlows + otherFlows; ++i)
+        {
+          detailsSs << "," << std::to_string (edgeDelays[i]);
+        }
+
+      detailsSs << "us-";
     }
-
-    detailsSs << "us-";
-  }
-
-  detailsSs <<
-    packet_size << "B-" <<
-    durS << "s";
+  detailsSs << payloadB << "B-" << durS << "s";
   std::string details = detailsSs.str ();
 
-  if (ENABLE_TRACE) {
-    NS_LOG_INFO ("Enabling trace files.");
-    AsciiTraceHelper ath;
-    std::stringstream traceName;
-    traceName << outDir << "/trace-" << details << ".tr";
-    p2pRouter.EnableAsciiAll (ath.CreateFileStream (traceName.str ()));
-  }
-  if (pcap) {
-    NS_LOG_INFO ("Enabling pcap files.");
-    std::stringstream pcapName;
-    pcapName << outDir << "/" << details;
-    p2pRouter.EnablePcapAll (pcapName.str (), true);
-  }
+  if (trace)
+    {
+      NS_LOG_INFO ("Enabling trace files.");
+      AsciiTraceHelper ath;
+      std::stringstream traceName;
+      traceName << outDir << "/trace-" << details << ".tr";
+      p2pRouter.EnableAsciiAll (ath.CreateFileStream (traceName.str ()));
+    }
+  if (pcap)
+    {
+      NS_LOG_INFO ("Enabling pcap files.");
+      std::stringstream pcapName;
+      pcapName << outDir << "/" << details;
+      p2pRouter.EnablePcapAll (pcapName.str (), true);
+    }
 
-  Simulator::Schedule (Seconds (BBR_PRINT_PERIOD), PrintStats);
+  Simulator::Schedule (Seconds (PRINT_PERIOD), PrintStats);
 
   /////////////////////////////////////////
   // Run simulation.
@@ -471,7 +471,7 @@ int main (int argc, char *argv[])
                    " - avg tput: " << tputMbps << " Mb/s");
     }
   NS_LOG_INFO ("Jain's fairness index: " <<
-               pow(sumTputMbps, 2) / (sinks.size () * sumTputMbpsSq));
+               pow (sumTputMbps, 2) / (sinks.size () * sumTputMbpsSq));
 
   // Done.
   Simulator::Destroy ();

--- a/src/internet/model/tcp-socket-base.cc
+++ b/src/internet/model/tcp-socket-base.cc
@@ -442,8 +442,8 @@ TcpSocketBase::TcpSocketBase (const TcpSocketBase& sock)
     m_receivingBbr (sock.m_receivingBbr),
     m_ackPeriod (sock.m_ackPeriod),
     m_modelName (sock.m_modelName),
-    m_csvFileName (sock.m_csvFileName),
-    m_net (sock.m_net)
+    m_csvFileName (sock.m_csvFileName) //,
+    // m_net (sock.m_net)
     // Don't copy pendingAcks - don't want duplciate acks
     // Don't copy m_lossCounts and m_arrivalTimes because we want to reset those
     // for a new flow.
@@ -4399,10 +4399,11 @@ TcpSocketBase::EstimateAckPeriodModel (double targetTputMbps)
 
   // TODO: This scaling assumes a single input and output feature.
   // TODO: There is a bug here.
-  double out = m_net->forward (std::vector<torch::jit::IValue> ({
-        Scale (targetTputMbps * 1e6,
-               m_scaleParams.input[0].min, m_scaleParams.input[0].max, 0, 1)}))
-    .toTensor ().item ().to<double> ();
+  // double out = m_net->forward (std::vector<torch::jit::IValue> ({
+  //       Scale (targetTputMbps * 1e6,
+  //              m_scaleParams.input[0].min, m_scaleParams.input[0].max, 0, 1)}))
+  //   .toTensor ().item ().to<double> ();
+  double out = 0;
   double out_unscaled = Scale (out, 0, 1, m_scaleParams.output[0].min,
                                m_scaleParams.output[0].max);
   NS_LOG_DEBUG ("raw model output: " << out << ", unscaled: " << out_unscaled);
@@ -4751,15 +4752,15 @@ TcpSocketBase::SetModel (std::string modelFlp)
   ss << modelFlp.substr (0, lastDot + 1) << "csv";
   m_scaleParams = ReadScaleParams (ss.str ());
 
-  try
-    {
-      torch::jit::script::Module net = torch::jit::load (modelFlp);
-      m_net = &net;
-    }
-  catch (const c10::Error& e)
-    {
-      NS_LOG_ERROR ("Error loading model " << modelFlp << ":\n" << e.what ());
-    }
+  // try
+  //   {
+  //     torch::jit::script::Module net = torch::jit::load (modelFlp);
+  //     m_net = &net;
+  //   }
+  // catch (const c10::Error& e)
+  //   {
+  //     NS_LOG_ERROR ("Error loading model " << modelFlp << ":\n" << e.what ());
+  //   }
 }
 
 std::string

--- a/src/internet/model/tcp-socket-base.h
+++ b/src/internet/model/tcp-socket-base.h
@@ -21,10 +21,11 @@
 #ifndef TCP_SOCKET_BASE_H
 #define TCP_SOCKET_BASE_H
 
-#include <stdint.h>
-#include <queue>
 #include <iostream>
 #include <fstream>
+#include <queue>
+#include <stdint.h>
+#include <unordered_set>
 
 #include "ns3/traced-value.h"
 #include "ns3/tcp-socket.h"

--- a/src/internet/model/tcp-socket-base.h
+++ b/src/internet/model/tcp-socket-base.h
@@ -40,7 +40,7 @@
 #include "rtt-estimator.h"
 #include "tcp-l4-protocol.h"
 
-#include <torch/script.h>
+// #include <torch/script.h>
 
 namespace ns3 {
 
@@ -1378,7 +1378,7 @@ protected:
   std::string m_modelName                     {""};
   std::string m_csvFileName                   {""};
   std::ofstream m_csvFile;
-  torch::jit::script::Module *m_net      {nullptr};
+  // torch::jit::script::Module *m_net      {nullptr};
 
 
 public:

--- a/src/network/utils/net-device-queue-interface.h
+++ b/src/network/utils/net-device-queue-interface.h
@@ -377,7 +377,7 @@ NetDeviceQueue::PacketEnqueued (Ptr<Queue<Item> > queue,
     {
       NS_LOG_DEBUG ("The device queue is being stopped (" << queue->GetNPackets ()
                     << " packets and " << queue->GetNBytes () << " bytes inside)");
-      ndqi->GetTxQueue (txq)->Stop ();
+      //ndqi->GetTxQueue (txq)->Stop ();
     }
 }
 
@@ -426,8 +426,7 @@ NetDeviceQueue::PacketDiscarded (Ptr<Queue<Item> > queue,
 
   NS_LOG_ERROR ("BUG! No room in the device queue for the received packet! ("
                 << queue->GetNPackets () << " packets and " << queue->GetNBytes () << " bytes inside)");
-
-  ndqi->GetTxQueue (txq)->Stop ();
+  //ndqi->GetTxQueue (txq)->Stop ();
 }
 
 } // namespace ns3

--- a/wscript
+++ b/wscript
@@ -724,6 +724,11 @@ def create_ns3_program(bld, name, dependencies=('core',)):
     program.includes = "#"
     program.use = program.ns3_module_dependencies
 
+    # Add boost.
+    program.env.append_value('LINKFLAGS', '-L/usr/lib/x86_64-linux-gnu')
+    program.env.append_value("LIB", "boost_filesystem")
+    program.env.append_value("LIB", "boost_system")
+
     # Add libtorch.
     program.env.append_value('CPPFLAGS', '-I/opt/libtorch/include')
     program.env.append_value('LINKFLAGS', '-L/opt/libtorch/lib')


### PR DESCRIPTION
This PR cleans up `dumbbell.cc`, adopts ns-3's style conventions, and changes the output structure. Now, each simulation creates a new directory in which to store its results so as to not overwhelm the provided output directory when running many simulations.