### PR TITLE
[WIP] Refactor unfair simulator to handle arbitrary CCAs

### DIFF
--- a/scratch/dumbbell.cc
+++ b/scratch/dumbbell.cc
@@ -237,9 +237,9 @@ int main (int argc, char *argv[])
   NS_LOG_INFO ("Setting configuration parameters.");
   ConfigStore config;
   config.ConfigureDefaults ();
-  // Select which TCP variant to use.
-  Config::SetDefault ("ns3::TcpL4Protocol::SocketType",
-                      StringValue (otherProto));
+  // // Select which TCP variant to use.
+  // Config::SetDefault ("ns3::TcpL4Protocol::SocketType",
+  //                     StringValue (otherProto));
   // Set the segment size (otherwise, ns-3's default is 536).
   Config::SetDefault ("ns3::TcpSocket::SegmentSize",
                       UintegerValue (payloadB));

--- a/scratch/dumbbell.cc
+++ b/scratch/dumbbell.cc
@@ -151,12 +151,12 @@ int main (int argc, char *argv[])
   bool pcap = false;
   bool trace = false;
   boost::filesystem::path outDir = ".";
-  const char *edge_delay_usage = "List of the edge delays (us) for unfair flows in the "
-                                 "dumbbell topology seperated by comma."
-                                 "Be mindful that both left and right edge will have the same delay. "
-                                 "Edges will have the default delay (500us) if not specified"
-                                 "(e.g. \"1000,500,1000,2000\"). Also, there's a shortcut to specify the same "
-                                 "delay for all flows, using [1000] instead of comma seperated string.";
+  const char *edge_delay_usage = "List of the edge delays (us) for \"unfair\" flows in the "
+                                 "dumbbell topology, seperated by a comma (e.g. \"1000,500,1000,2000\")."
+                                 "Be mindful that both the \"left\" and \"right\" edges will have the same delay. "
+                                 "Edges will have the default delay (500us) if this option is not specified."
+                                 "Also, there is a shortcut to specify the same delay for all flows, using "
+                                 "[1000] instead of a comma-seperated string.";
   CommandLine cmd;
   cmd.AddValue ("bottleneck_bandwidth_Mbps", "Bandwidth for the bottleneck link (Mbps).", btlBwMbps);
   cmd.AddValue ("bottleneck_delay_us", "Delay across the bottleneck link (us).", btlDelUs);

--- a/scratch/dumbbell.cc
+++ b/scratch/dumbbell.cc
@@ -206,7 +206,7 @@ int main (int argc, char *argv[])
 
   /////////////////////////////////////////
   // Turn on logging and report parameters.
-  // Note: For BBR', other components that may be of interest include "TcpBbr"
+  // Note: For BBR, other components that may be of interest include "TcpBbr"
   //       and "BbrState".
   LogComponentEnable ("main", LOG_LEVEL_INFO);
 
@@ -261,7 +261,8 @@ int main (int argc, char *argv[])
                       TimeValue (MicroSeconds (0)));
   // Configure TcpSocketBase with the model filepath.
   Config::SetDefault ("ns3::TcpSocketBase::Model", StringValue (modelFlp));
-  // Configure TcpSocketBase with the model filepath.
+  // Configure TcpSocketBase with how long to wait before beginning
+  // unfairness mitigation.
   Config::SetDefault ("ns3::TcpSocketBase::UnfairMitigationDelayStart",
                       TimeValue (Seconds (warmupS)));
   // Configure the number of packet records that TcpSocketBase will maintain.

--- a/scratch/dumbbell.cc
+++ b/scratch/dumbbell.cc
@@ -436,8 +436,10 @@ int main (int argc, char *argv[])
 
   // Create output directory and base output filepath.
   outDir /= details;
+  NS_LOG_DEBUG ("Verifying that output directory does not exist: " << outDir);
   NS_ABORT_UNLESS (! boost::filesystem::exists (outDir));
-  boost::filesystem::create_directory (outDir);
+  NS_LOG_DEBUG ("Creating output directory: " << outDir);
+  boost::filesystem::create_directories (outDir);
   boost::filesystem::path outFlp = outDir;
   outFlp /= details;
 

--- a/scratch/dumbbell.cc
+++ b/scratch/dumbbell.cc
@@ -485,13 +485,21 @@ int main (int argc, char *argv[])
   NS_LOG_INFO ("Flows:");
   for (auto& sink : sinks)
     {
-      double tputMbps = sink->GetTotalRx () * 8 / durS / 1e6;
-      sumTputMbps += tputMbps;
-      sumTputMbpsSq += pow (tputMbps, 2);
-      Ptr<TcpSocketBase> sock = DynamicCast<TcpSocketBase> (
-        sink->GetSockets ().front ());
-      NS_LOG_INFO ("  " << (sock->GetReceivingBbr () ? "BBR" : "Other") <<
-                   " - avg tput: " << tputMbps << " Mb/s");
+      int num_socks = sink->GetSockets ().size ();
+      if (num_socks == 0)
+        {
+          NS_LOG_WARN ("No sockets for this sink!");
+        }
+      else
+        {
+          double tputMbps = sink->GetTotalRx () * 8 / durS / 1e6;
+          sumTputMbps += tputMbps;
+          sumTputMbpsSq += pow (tputMbps, 2);
+          Ptr<TcpSocketBase> sock = DynamicCast<TcpSocketBase> (
+            sink->GetSockets ().front ());
+          NS_LOG_INFO ("  " << (sock->GetReceivingBbr () ? "BBR" : "Other") <<
+                       " - avg tput: " << tputMbps << " Mb/s");
+        }
     }
   NS_LOG_INFO ("Jain's fairness index: " <<
                pow (sumTputMbps, 2) / (sinks.size () * sumTputMbpsSq));

--- a/src/internet/model/tcp-socket-base.cc
+++ b/src/internet/model/tcp-socket-base.cc
@@ -4125,7 +4125,6 @@ TcpSocketBase::Unfair (Ptr<Packet> p, SequenceNumber32 seq) {
   // Debug logging.
   NS_LOG_DEBUG ("one-way delay: " << Simulator::Now () - tag.sndTime);
   NS_LOG_DEBUG ("tag.sndTime: " << tag.sndTime);
-  NS_LOG_DEBUG ("tag.isBbr: " << tag.isBbr);
   NS_LOG_DEBUG ("m_receivingBbr: " << std::string (m_receivingBbr ? "Yes" : "No"));
   std::string fairShareTypeStr = FairShareTypeToStr (m_fairShareType);
   NS_LOG_DEBUG ("m_fairShareType" << fairShareTypeStr);


### PR DESCRIPTION
Currently, the unfair project simulator supports BBR as the "unfair" CCA and either BBR, Cubic, or NewReno as the "fair" CCA. This PR will refactor `dumbbell.cc` and `tcp-socket-base.{h,cc}` to support any combination of CCAs. Instead of having "fair" and "unfair" flows, each flow's CCA will be able to be set separately. In the fully general case, each flow will be able to have a different CCA.